### PR TITLE
Fix bit shift overflow when reading cartridge size from header

### DIFF
--- a/wii7800/src/Cartridge.cpp
+++ b/wii7800/src/Cartridge.cpp
@@ -117,7 +117,7 @@ static void cartridge_ReadHeader(const byte* header) {
   }
   cartridge_title = temp;
     
-  cartridge_size  = header[49] << 32; // Why 32?  
+  cartridge_size  = header[49] << 24;
   cartridge_size |= header[50] << 16;
   cartridge_size |= header[51] << 8;
   cartridge_size |= header[52];


### PR DESCRIPTION
`left shift count >= width of type`

With optimization on, `cartridge_size` will result in garbage/undefined behavior and break loading of games not found in the database, because the size will always be > 131072 and wrongly identify `cartridge_type` as `CARTRIDGE_TYPE_SUPERCART_LARGE`
